### PR TITLE
Fix model handling and add safety checks for llama native integration

### DIFF
--- a/app/src/main/java/edu/upt/assistant/domain/ChatRepositoryImpl.kt
+++ b/app/src/main/java/edu/upt/assistant/domain/ChatRepositoryImpl.kt
@@ -50,6 +50,10 @@ class ChatRepositoryImpl @Inject constructor(
             val modelPath = modelDownloadManager.getModelPath()
             Log.d("ChatRepository", "Model path: $modelPath")
             val ctx = LlamaNative.llamaCreate(modelPath)
+            if (ctx == 0L) {
+                Log.e("ChatRepository", "Failed to create llama context")
+                throw IllegalStateException("Failed to create llama context")
+            }
             Log.d("ChatRepository", "Llama context created: $ctx")
             _llamaCtx = ctx
             ctx


### PR DESCRIPTION
## Summary
- keep llama model loaded and free it together with the context
- add null checks for model and vocab before tokenization
- validate JNI context creation in repository

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6898aff035b8832886889e50dd5b972c