### PR TITLE
Expose thread count for llama context

### DIFF
--- a/app/src/main/java/edu/upt/assistant/LlamaNative.kt
+++ b/app/src/main/java/edu/upt/assistant/LlamaNative.kt
@@ -7,7 +7,7 @@ fun interface TokenCallback {
 object LlamaNative {
   init { System.loadLibrary("llama_jni") }
 
-  @JvmStatic external fun llamaCreate(modelPath: String): Long
+  @JvmStatic external fun llamaCreate(modelPath: String, nThreads: Int): Long
   @JvmStatic external fun llamaGenerate(ctxPtr: Long, prompt: String, maxTokens: Int): String
   @JvmStatic external fun llamaGenerateStream(
     ctxPtr: Long,

--- a/app/src/main/java/edu/upt/assistant/domain/ChatRepositoryImpl.kt
+++ b/app/src/main/java/edu/upt/assistant/domain/ChatRepositoryImpl.kt
@@ -21,6 +21,7 @@ import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.lang.Runtime
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -49,7 +50,10 @@ class ChatRepositoryImpl @Inject constructor(
 
             val modelPath = modelDownloadManager.getModelPath()
             Log.d("ChatRepository", "Model path: $modelPath")
-            val ctx = LlamaNative.llamaCreate(modelPath)
+            val ctx = LlamaNative.llamaCreate(
+                modelPath,
+                Runtime.getRuntime().availableProcessors()
+            )
             if (ctx == 0L) {
                 Log.e("ChatRepository", "Failed to create llama context")
                 throw IllegalStateException("Failed to create llama context")


### PR DESCRIPTION
## Summary
- allow specifying thread count when creating the llama context via JNI
- default to hardware concurrency when thread count isn't provided
- pass available processor count from ChatRepository

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6898b66037908328b4aaab149c3b7305