### PR TITLE
Handle end-of-turn tokens during generation

### DIFF
--- a/app/src/main/cpp/llama_jni.cpp
+++ b/app/src/main/cpp/llama_jni.cpp
@@ -113,6 +113,13 @@ Java_edu_upt_assistant_LlamaNative_llamaGenerate(
         auto tok = static_cast<llama_token>(best);
         const char* piece = llama_vocab_get_text(vocab, tok);
         if (!piece) break;
+        // Stop if the model signaled end of turn
+        if (strcmp(piece, "<end_of_turn>") == 0) {
+            llama_batch b2 = llama_batch_get_one(&tok, 1);
+            llama_decode(ctx, b2);
+            llama_batch_free(b2);
+            break;
+        }
         out += piece;
 
         // decode this token
@@ -167,7 +174,7 @@ Java_edu_upt_assistant_LlamaNative_llamaGenerateStream(
 
     // Prepare Java callback method
     jclass cbCls = env->GetObjectClass(callback);
-    jmethodID onToken = env->GetMethodID(cbCls, "onToken", "(Ljava/lang/String;)V");
+    jmethodID onToken = env->GetMethodID(cbCls, "onToken", "(Ljava/lang/String;)Z");
     int32_t vocab_size = llama_n_vocab(vocab);
 
     // Stream tokens as generated
@@ -185,9 +192,22 @@ Java_edu_upt_assistant_LlamaNative_llamaGenerateStream(
         auto tok = static_cast<llama_token>(best);
         const char* piece = llama_vocab_get_text(vocab, tok);
         if (!piece) break;
+        // Stop if the model signaled end of turn
+        if (strcmp(piece, "<end_of_turn>") == 0) {
+            llama_batch b2 = llama_batch_get_one(&tok, 1);
+            llama_decode(ctx, b2);
+            llama_batch_free(b2);
+            break;
+        }
         jstring pieceJ = env->NewStringUTF(piece);
-        env->CallVoidMethod(callback, onToken, pieceJ);
+        jboolean cont = env->CallBooleanMethod(callback, onToken, pieceJ);
         env->DeleteLocalRef(pieceJ);
+        if (cont == JNI_FALSE) {
+            llama_batch b2 = llama_batch_get_one(&tok, 1);
+            llama_decode(ctx, b2);
+            llama_batch_free(b2);
+            break;
+        }
 
         llama_batch b2 = llama_batch_get_one(&tok, 1);
         if (llama_decode(ctx, b2) != 0) {

--- a/app/src/main/java/edu/upt/assistant/LlamaNative.kt
+++ b/app/src/main/java/edu/upt/assistant/LlamaNative.kt
@@ -1,7 +1,10 @@
 package edu.upt.assistant
 
 fun interface TokenCallback {
-  fun onToken(token: String)
+  /**
+   * @return true to continue streaming, false to stop generation
+   */
+  fun onToken(token: String): Boolean
 }
 
 object LlamaNative {

--- a/app/src/main/java/edu/upt/assistant/domain/ChatRepositoryImpl.kt
+++ b/app/src/main/java/edu/upt/assistant/domain/ChatRepositoryImpl.kt
@@ -119,6 +119,7 @@ class ChatRepositoryImpl @Inject constructor(
 
             // 3) stream tokens
             val builder = StringBuilder()
+            var ended = false
             withContext(Dispatchers.Default) {
                 Log.d("ChatRepository", "Starting token generation")
                 LlamaNative.llamaGenerateStream(
@@ -127,6 +128,11 @@ class ChatRepositoryImpl @Inject constructor(
                     /* maxTokens = */ 128,
                     TokenCallback { token ->
                         Log.d("ChatRepository", "Generated token: $token")
+                        if (ended) return@TokenCallback false
+                        if (token == "<end_of_turn>") {
+                            ended = true
+                            return@TokenCallback false
+                        }
                         val success = trySend(token).isSuccess
                         if (success) {
                             builder.append(token)


### PR DESCRIPTION
## Summary
- stop C++ generation loop when `<end_of_turn>` appears
- let Kotlin callbacks return `Boolean` to control streaming
- ignore tokens after the first end-of-turn in `ChatRepositoryImpl`

## Testing
- `./gradlew test` *(failed: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6898c1a058a48328a966eb9054fd5703