### PR TITLE
Normalize streaming tokens

### DIFF
--- a/app/src/main/java/edu/upt/assistant/domain/ChatRepositoryImpl.kt
+++ b/app/src/main/java/edu/upt/assistant/domain/ChatRepositoryImpl.kt
@@ -156,9 +156,13 @@ class ChatRepositoryImpl @Inject constructor(
                         /* maxTokens = */ 128,
                         TokenCallback { token ->
                             Log.d("ChatRepository", "Generated token: $token")
-                            val success = trySend(token).isSuccess
+
+                            val normalized = token.replace("▁", " ")
+                            val output = if (builder.isEmpty()) normalized.trimStart() else normalized
+
+                            val success = trySend(output).isSuccess
                             if (success) {
-                                builder.append(token)
+                                builder.append(output)
                             }
                             // Keep the callback alive
                         }


### PR DESCRIPTION
## Summary
- Normalize LLM tokens by replacing `▁` with spaces before streaming
- Trim leading spaces on the first token to avoid spaced message starts

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689a3a6e6c588328ac81a8ce0f186a23