### PR TITLE
Add system bars padding to setup screen

### DIFF
--- a/app/src/main/java/edu/upt/assistant/ui/screens/SetupScreen.kt
+++ b/app/src/main/java/edu/upt/assistant/ui/screens/SetupScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -154,6 +155,7 @@ fun SetupStep1(
     Column(
         Modifier
             .fillMaxSize()
+            .systemBarsPadding()
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
@@ -218,6 +220,7 @@ fun SetupStep2(
     Column(
         Modifier
             .fillMaxSize()
+            .systemBarsPadding()
             .verticalScroll(rememberScrollState())
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)


### PR DESCRIPTION
## Summary
- Ensure setup flow respects system bars by padding root columns
- Keep Next and Finish buttons above navigation areas

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689b3691e3388328a45dd3283f96f521