### PR TITLE
Fix setup completion flag for navigation

### DIFF
--- a/app/src/main/java/edu/upt/assistant/domain/SettingsViewModel.kt
+++ b/app/src/main/java/edu/upt/assistant/domain/SettingsViewModel.kt
@@ -27,7 +27,7 @@ class SettingsViewModel @Inject constructor(
     .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
   val setupDone: StateFlow<Boolean> = dataStore.data
-    .map { prefs -> prefs[SettingsKeys.NOTIFICATIONS] ?: false }
+    .map { prefs -> prefs[SettingsKeys.SETUP_DONE] ?: false }
     .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
   // Update username


### PR DESCRIPTION
## Summary
- read the setup completion state from `SettingsKeys.SETUP_DONE`
- start route now respects onboarding completion flag

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689b3bcd4abc832881a01f7be4d0d051