### PR TITLE
feat: allow configurable model downloads

### DIFF
--- a/app/src/main/java/edu/upt/assistant/data/SettingsKeys.kt
+++ b/app/src/main/java/edu/upt/assistant/data/SettingsKeys.kt
@@ -10,4 +10,5 @@ object SettingsKeys {
   val INTERESTS = stringPreferencesKey("interests")
   val CUSTOM_INTEREST = stringPreferencesKey("custom_interest")
   val BIRTHDAY = stringPreferencesKey("birthday")
+  val MODEL_URL = stringPreferencesKey("model_url")
 }

--- a/app/src/main/java/edu/upt/assistant/domain/SettingsViewModel.kt
+++ b/app/src/main/java/edu/upt/assistant/domain/SettingsViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import edu.upt.assistant.data.SettingsKeys
+import edu.upt.assistant.domain.ModelDownloadManager
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -30,6 +31,10 @@ class SettingsViewModel @Inject constructor(
     .map { prefs -> prefs[SettingsKeys.SETUP_DONE] ?: false }
     .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
+  val modelUrl: StateFlow<String> = dataStore.data
+    .map { prefs -> prefs[SettingsKeys.MODEL_URL] ?: ModelDownloadManager.DEFAULT_MODEL_URL }
+    .stateIn(viewModelScope, SharingStarted.Eagerly, ModelDownloadManager.DEFAULT_MODEL_URL)
+
   // Update username
   fun setUsername(name: String) = viewModelScope.launch {
     dataStore.edit { prefs ->
@@ -41,6 +46,12 @@ class SettingsViewModel @Inject constructor(
   fun setNotificationsEnabled(enabled: Boolean) = viewModelScope.launch {
     dataStore.edit { prefs ->
       prefs[SettingsKeys.NOTIFICATIONS] = enabled
+    }
+  }
+
+  fun setModelUrl(url: String) = viewModelScope.launch {
+    dataStore.edit { prefs ->
+      prefs[SettingsKeys.MODEL_URL] = url
     }
   }
 }

--- a/app/src/main/java/edu/upt/assistant/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/edu/upt/assistant/ui/navigation/AppNavGraph.kt
@@ -39,6 +39,7 @@ fun AppNavGraph(
     val username by settingsVm.username.collectAsState(initial = "")
     val notifications by settingsVm.notificationsEnabled.collectAsState(initial = false)
     val setupDone by settingsVm.setupDone.collectAsState(initial = false)
+    val modelUrl by settingsVm.modelUrl.collectAsState(initial = ModelDownloadManager.DEFAULT_MODEL_URL)
 
     // pick start based on whether onboarding completed
     val startRoute = if (setupDone) NEW_CHAT_ROUTE else SETUP_ROUTE
@@ -61,7 +62,7 @@ fun AppNavGraph(
             NewChatScreen(
                 username = username,
                 onStartChat = { initial ->
-                    if (!modelDownloadManager.isModelAvailable()) {
+                    if (!modelDownloadManager.isModelAvailable(modelUrl)) {
                         navController.navigate(MODEL_DOWNLOAD_ROUTE)
                     } else {
                         // Generate the ID immediately:
@@ -131,7 +132,9 @@ fun AppNavGraph(
                 onUserNameChange = { settingsVm.setUsername(it) },
                 onNotificationsToggle = { settingsVm.setNotificationsEnabled(it) },
                 onBack = { navController.popBackStack() },
-                onDownloadModel = { navController.navigate(MODEL_DOWNLOAD_ROUTE) }
+                onDownloadModel = { navController.navigate(MODEL_DOWNLOAD_ROUTE) },
+                modelUrl = modelUrl,
+                onModelUrlChange = { settingsVm.setModelUrl(it) }
             )
         }
 
@@ -142,7 +145,8 @@ fun AppNavGraph(
                     navController.navigate(NEW_CHAT_ROUTE) {
                         popUpTo(MODEL_DOWNLOAD_ROUTE) { inclusive = true }
                     }
-                }
+                },
+                modelUrl = modelUrl
             )
         }
     }


### PR DESCRIPTION
## Summary
- make model URL configurable via settings and DataStore
- support dynamic model download and management
- load chosen model when starting chats

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689b413b517c8328a271672261f01a41