### PR TITLE
fix: enable scrolling in settings screen

### DIFF
--- a/app/src/main/java/edu/upt/assistant/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/edu/upt/assistant/ui/screens/SettingsScreen.kt
@@ -1,6 +1,8 @@
 package edu.upt.assistant.ui.screens
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CloudDownload
@@ -122,6 +124,7 @@ fun SettingsScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
+                .verticalScroll(rememberScrollState())
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(24.dp)
         ) {


### PR DESCRIPTION
## Summary
- allow Settings screen content to scroll so model actions remain accessible

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c98c01308328afc7062ff39bc67b