### PR TITLE
Collect model state per-route in AppNavGraph

### DIFF
--- a/app/src/main/java/edu/upt/assistant/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/edu/upt/assistant/ui/navigation/AppNavGraph.kt
@@ -37,10 +37,7 @@ fun AppNavGraph(
     // collect conversations reactively
     val conversations by vm.conversations.collectAsState()
     val username by settingsVm.username.collectAsState(initial = "")
-    val notifications by settingsVm.notificationsEnabled.collectAsState(initial = false)
     val setupDone by settingsVm.setupDone.collectAsState(initial = false)
-    val modelUrls by settingsVm.modelUrls.collectAsState(initial = setOf(ModelDownloadManager.DEFAULT_MODEL_URL))
-    val activeModel by settingsVm.activeModel.collectAsState(initial = ModelDownloadManager.DEFAULT_MODEL_URL)
 
     // pick start based on whether onboarding completed
     val startRoute = if (setupDone) NEW_CHAT_ROUTE else SETUP_ROUTE
@@ -60,6 +57,8 @@ fun AppNavGraph(
 
         // 1) Setup / New Chat Screen
         composable(NEW_CHAT_ROUTE) {
+            val activeModel by settingsVm.activeModel.collectAsState(initial = ModelDownloadManager.DEFAULT_MODEL_URL)
+
             NewChatScreen(
                 username = username,
                 onStartChat = { initial ->
@@ -123,6 +122,8 @@ fun AppNavGraph(
             val settingsVm: SettingsViewModel = hiltViewModel()
             val username by settingsVm.username.collectAsState()
             val notificationsEnabled by settingsVm.notificationsEnabled.collectAsState()
+            val modelUrls by settingsVm.modelUrls.collectAsState(initial = setOf(ModelDownloadManager.DEFAULT_MODEL_URL))
+            val activeModel by settingsVm.activeModel.collectAsState(initial = ModelDownloadManager.DEFAULT_MODEL_URL)
 
             SettingsScreen(
                 username = username,
@@ -140,6 +141,8 @@ fun AppNavGraph(
 
         // 5) Model Download Screen
         composable(MODEL_DOWNLOAD_ROUTE) {
+            val activeModel by settingsVm.activeModel.collectAsState(initial = ModelDownloadManager.DEFAULT_MODEL_URL)
+
             ModelDownloadScreen(
                 onModelReady = {
                     navController.navigate(NEW_CHAT_ROUTE) {


### PR DESCRIPTION
## Summary
- remove top-level model URL and active model state
- collect active model and model URLs within each NavHost route and pass to screens

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dc6be7208328a5d430fc5cccb50c