### PR TITLE
feat: add download state handling in settings

### DIFF
--- a/app/src/main/java/edu/upt/assistant/ui/screens/ModelDownloadViewModel.kt
+++ b/app/src/main/java/edu/upt/assistant/ui/screens/ModelDownloadViewModel.kt
@@ -27,10 +27,15 @@ class ModelDownloadViewModel @Inject constructor(
     private val _downloadState = MutableStateFlow<DownloadState>(DownloadState.NotStarted)
     val downloadState: StateFlow<DownloadState> = _downloadState.asStateFlow()
 
-    private var currentUrl: String = ""
+    private val _currentUrl = MutableStateFlow("")
+    val currentUrl: StateFlow<String> = _currentUrl.asStateFlow()
+
+    fun fileNameFrom(url: String): String = downloadManager.fileNameFrom(url)
+
+    fun isModelAvailable(url: String): Boolean = downloadManager.isModelAvailable(url)
 
     fun setModelUrl(url: String) {
-        currentUrl = url
+        _currentUrl.value = url
         _downloadState.value = if (downloadManager.isModelAvailable(url)) {
             DownloadState.Completed
         } else {
@@ -39,7 +44,7 @@ class ModelDownloadViewModel @Inject constructor(
     }
 
     fun startDownload() {
-        val url = currentUrl
+        val url = _currentUrl.value
         if (url.isBlank() || _downloadState.value is DownloadState.Downloading) return
 
         viewModelScope.launch {
@@ -64,7 +69,7 @@ class ModelDownloadViewModel @Inject constructor(
     }
 
     fun deleteModel() {
-        val url = currentUrl
+        val url = _currentUrl.value
         if (url.isBlank()) return
         viewModelScope.launch {
             downloadManager.deleteModel(url)


### PR DESCRIPTION
## Summary
- expose model download progress and current URL in `ModelDownloadViewModel`
- observe download state in `SettingsScreen` and show progress/error feedback

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ddf8a3248328b067d7362a876fc3