### PR TITLE
Clear URL state after model deletion

### DIFF
--- a/app/src/main/java/edu/upt/assistant/ui/screens/ModelDownloadViewModel.kt
+++ b/app/src/main/java/edu/upt/assistant/ui/screens/ModelDownloadViewModel.kt
@@ -20,11 +20,13 @@ class ModelDownloadViewModel @Inject constructor(
     private val _downloadState = MutableStateFlow<DownloadState>(DownloadState.NotStarted)
     val downloadState: StateFlow<DownloadState> = _downloadState.asStateFlow()
 
-    private var currentUrl: String = ""
+    private val _currentUrl = MutableStateFlow("")
+    val currentUrl: StateFlow<String> = _currentUrl.asStateFlow()
+
     private var downloadJob: Job? = null
 
     fun setModelUrl(url: String) {
-        currentUrl = url
+        _currentUrl.value = url
         _downloadState.value = if (downloadManager.isModelAvailableUrl(url)) {
             DownloadState.Completed
         } else {
@@ -33,7 +35,7 @@ class ModelDownloadViewModel @Inject constructor(
     }
 
     fun startDownload() {
-        val url = currentUrl
+        val url = _currentUrl.value
         if (url.isBlank() || _downloadState.value is DownloadState.Downloading) return
 
         downloadJob?.cancel()
@@ -59,11 +61,12 @@ class ModelDownloadViewModel @Inject constructor(
     }
 
     fun deleteModel() {
-        val url = currentUrl
+        val url = _currentUrl.value
         if (url.isBlank()) return
         viewModelScope.launch {
             downloadManager.deleteModel(url)
             _downloadState.value = DownloadState.NotStarted
+            _currentUrl.value = ""
         }
     }
 


### PR DESCRIPTION
## Summary
- Track current model URL via StateFlow in `ModelDownloadViewModel`
- Reset current URL when deleting a model

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fb5c1e7c8328a59eb6225587419c