### PR TITLE
Handle model download errors in settings

### DIFF
--- a/app/src/main/java/edu/upt/assistant/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/edu/upt/assistant/ui/screens/SettingsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import android.util.Log
 import edu.upt.assistant.domain.ModelDownloadManager
 import kotlinx.coroutines.launch
 
@@ -160,7 +161,13 @@ fun SettingsScreen(
               } else {
                 TextButton(
                   onClick = {
-                    scope.launch { downloadManager.downloadModel(url).collect {/* no-op */} }
+                    scope.launch {
+                      try {
+                        downloadManager.downloadModel(url).collect { /* no-op */ }
+                      } catch (e: Exception) {
+                        Log.e("SettingsScreen", "Model download failed", e)
+                      }
+                    }
                   }
                 ) {
                   Icon(Icons.Default.CloudDownload, contentDescription = null)


### PR DESCRIPTION
## Summary
- Prevent Settings screen crash by catching model download failures
- Log a descriptive error when model downloads fail

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a0ff4dc354832897ede17be5d16a0d