### PR TITLE
Normalize tokens across models

### DIFF
--- a/app/src/main/java/edu/upt/assistant/domain/ChatRepositoryImpl.kt
+++ b/app/src/main/java/edu/upt/assistant/domain/ChatRepositoryImpl.kt
@@ -154,7 +154,7 @@ class ChatRepositoryImpl @Inject constructor(
                         TokenCallback { token ->
                             Log.d("ChatRepository", "Generated token: $token")
 
-                            val normalized = token.replace("▁", " ")
+                            val normalized = normalizeToken(token)
                             val output = if (builder.isEmpty()) normalized.trimStart() else normalized
 
                             val success = trySend(output).isSuccess
@@ -211,6 +211,14 @@ class ChatRepositoryImpl @Inject constructor(
     }
 
     fun getDownloadManager(): ModelDownloadManager = modelDownloadManager
+
+    private fun normalizeToken(token: String): String {
+        return token
+            .replace("▁", " ")            // SentencePiece space
+            .replace("Ġ", " ")            // BPE space
+            .replace("Ċ", "\n")          // BPE newline
+            .replace("Äł", " ")           // Qwen space artefact
+    }
 
     // -- Helpers to convert between Entity ⇄ Domain --
     private fun ConversationEntity.toDomain() =


### PR DESCRIPTION
## Summary
- sanitize streamed tokens for multiple model tokenizers
- support space/newline markers from GPT-style and Qwen vocabularies

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a9bd28c88328a304228bb1956327