### PR TITLE
Fix initial streaming state and token collection in ChatRoute

### DIFF
--- a/app/src/main/java/edu/upt/assistant/domain/ChatViewModel.kt
+++ b/app/src/main/java/edu/upt/assistant/domain/ChatViewModel.kt
@@ -80,11 +80,10 @@ class ChatViewModel @Inject constructor(
      */
     fun startNewConversation(conversationId: String, initialText: String) {
         Log.d("ChatViewModel", "Starting new conversation: $conversationId with message: $initialText")
+        _currentStreamingConversation.value = conversationId
 
         viewModelScope.launch {
             try {
-                _currentStreamingConversation.value = conversationId
-
                 // 1) Create conversation metadata
                 val timestamp = currentTimeLabel()
                 repo.createConversation(
@@ -123,11 +122,10 @@ class ChatViewModel @Inject constructor(
      */
     fun sendMessage(conversationId: String, text: String) {
         Log.d("ChatViewModel", "Sending message to $conversationId: $text")
+        _currentStreamingConversation.value = conversationId
 
         viewModelScope.launch {
             try {
-                _currentStreamingConversation.value = conversationId
-
                 repo.sendMessage(conversationId, text)
                     .flowOn(Dispatchers.Default)
                     .onEach { token ->

--- a/app/src/main/java/edu/upt/assistant/ui/screens/ChatRoute.kt
+++ b/app/src/main/java/edu/upt/assistant/ui/screens/ChatRoute.kt
@@ -49,7 +49,7 @@ fun ChatRoute(
     var streamingMessage by remember { mutableStateOf("") }
 
     // Collect tokens from the SharedFlow when streaming this conversation
-    LaunchedEffect(conversationId) {
+    LaunchedEffect(conversationId, currentStreamingConversation) {
         vm.streamedTokens
             .filter { currentStreamingConversation == conversationId }
             .collect { token ->


### PR DESCRIPTION
## Summary
- Set current streaming conversation before launching coroutines so UI sees streaming state immediately
- Restart token collector when streaming conversation changes to avoid stale filters

## Testing
- ⚠️ `./gradlew test` *(failed: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a1b3fbf83c8328beb80bc18e711eb8