### PR TITLE
Pass shared ChatViewModel to chat route

### DIFF
--- a/app/src/main/java/edu/upt/assistant/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/edu/upt/assistant/ui/navigation/AppNavGraph.kt
@@ -107,12 +107,12 @@ fun AppNavGraph(
             val initialMessage = backStackEntry.arguments?.getString("initialMessage")
 
             if (convId != null) {
+                val decodedInitial = initialMessage?.let { URLDecoder.decode(it, "UTF-8") }
                 ChatRoute(
                     conversationId = convId,
                     navController = navController,
-                    initialMessage = initialMessage?.let {
-                        URLDecoder.decode(it, "UTF-8")
-                    }
+                    vm = vm,
+                    initialMessage = decodedInitial
                 )
             }
         }

--- a/app/src/main/java/edu/upt/assistant/ui/screens/ChatRoute.kt
+++ b/app/src/main/java/edu/upt/assistant/ui/screens/ChatRoute.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import edu.upt.assistant.domain.ChatViewModel
 import edu.upt.assistant.ui.navigation.HISTORY_ROUTE
@@ -33,7 +32,7 @@ import kotlinx.coroutines.flow.filter
 fun ChatRoute(
     conversationId: String,
     navController: NavHostController,
-    vm: ChatViewModel = hiltViewModel(),
+    vm: ChatViewModel,
     initialMessage: String? = null
 ) {
     // Collect the messages from the VM


### PR DESCRIPTION
## Summary
- Pass existing ChatViewModel into ChatRoute from AppNavGraph
- Update ChatRoute to accept ChatViewModel directly instead of creating its own

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1bc6b68fc83288281caec299a6842