### PR TITLE
Improve model management in settings

### DIFF
--- a/app/src/main/java/edu/upt/assistant/domain/SettingsViewModel.kt
+++ b/app/src/main/java/edu/upt/assistant/domain/SettingsViewModel.kt
@@ -55,7 +55,10 @@ class SettingsViewModel @Inject constructor(
 
   fun setActiveModel(url: String) = viewModelScope.launch {
     dataStore.edit { prefs ->
-      prefs[SettingsKeys.SELECTED_MODEL] = url
+      val urls = prefs[SettingsKeys.MODEL_URLS] ?: emptySet()
+      if (urls.contains(url)) {
+        prefs[SettingsKeys.SELECTED_MODEL] = url
+      }
     }
   }
 
@@ -69,9 +72,10 @@ class SettingsViewModel @Inject constructor(
   fun removeModelUrl(url: String) = viewModelScope.launch {
     dataStore.edit { prefs ->
       val current = prefs[SettingsKeys.MODEL_URLS] ?: emptySet()
-      prefs[SettingsKeys.MODEL_URLS] = current - url
+      val updated = current - url
+      prefs[SettingsKeys.MODEL_URLS] = updated
       if (prefs[SettingsKeys.SELECTED_MODEL] == url) {
-        prefs[SettingsKeys.SELECTED_MODEL] = current.firstOrNull { it != url }
+        prefs[SettingsKeys.SELECTED_MODEL] = updated.firstOrNull()
           ?: ModelDownloadManager.DEFAULT_MODEL_URL
       }
     }

--- a/app/src/main/java/edu/upt/assistant/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/edu/upt/assistant/ui/screens/SettingsScreen.kt
@@ -137,6 +137,7 @@ fun SettingsScreen(
             val id = downloadManager.fileNameFrom(url)
             val isAvailable = downloadManager.isModelAvailable(id)
             var isDownloading by remember(url) { mutableStateOf(false) }
+            var progress by remember(url) { mutableStateOf(0) }
             Row(
               verticalAlignment = Alignment.CenterVertically,
               modifier = Modifier.fillMaxWidth()
@@ -161,14 +162,20 @@ fun SettingsScreen(
                 }
               } else {
                 if (isDownloading) {
-                  CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                  Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    LinearProgressIndicator(progress = progress / 100f, modifier = Modifier.width(80.dp))
+                    Spacer(Modifier.height(4.dp))
+                    Text("$progress%")
+                  }
                 } else {
                   TextButton(
                     onClick = {
                       scope.launch {
                         try {
                           isDownloading = true
-                          downloadManager.downloadModel(url).collect { /* no-op */ }
+                          downloadManager.downloadModel(url).collect { prog ->
+                            progress = prog.percentage
+                          }
                         } catch (e: Exception) {
                           Log.e("SettingsScreen", "Model download failed", e)
                         } finally {
@@ -181,6 +188,12 @@ fun SettingsScreen(
                     Spacer(Modifier.width(4.dp))
                     Text("Download")
                   }
+                }
+                Spacer(Modifier.width(8.dp))
+                TextButton(onClick = { onRemoveModel(url) }) {
+                  Icon(Icons.Default.Delete, contentDescription = null)
+                  Spacer(Modifier.width(4.dp))
+                  Text("Remove")
                 }
               }
             }


### PR DESCRIPTION
## Summary
- show download progress and allow removing unused model URLs
- validate active model selection and reset when removing URLs

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1bf418c4083288d43e8f89de76f6c