### PR TITLE
Refactor memory screen and connect repository

### DIFF
--- a/app/src/main/java/edu/upt/assistant/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/edu/upt/assistant/ui/navigation/AppNavGraph.kt
@@ -3,7 +3,6 @@ package edu.upt.assistant.ui.navigation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -12,7 +11,6 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
-import edu.upt.assistant.data.local.db.MemoryEntity
 import edu.upt.assistant.domain.ChatViewModel
 import edu.upt.assistant.domain.ModelDownloadManager
 import edu.upt.assistant.domain.SettingsViewModel
@@ -176,10 +174,8 @@ fun AppNavGraph(
 
         // 7) Memory Screen
         composable(MEMORY_ROUTE) {
-            val memoriesFlow = vm.getMemories()
-            val memories by memoriesFlow?.collectAsState(initial = emptyList())
-                ?: remember { mutableStateOf(emptyList()) }
-            
+            val memories by vm.getMemories().collectAsState(initial = emptyList())
+
             MemoryScreen(
                 memories = memories,
                 onAddMemory = { content, title, importance ->

--- a/app/src/main/java/edu/upt/assistant/ui/screens/MemoryScreen.kt
+++ b/app/src/main/java/edu/upt/assistant/ui/screens/MemoryScreen.kt
@@ -3,7 +3,9 @@ package edu.upt.assistant.ui.screens
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Star
@@ -26,89 +28,79 @@ fun MemoryScreen(
     onBack: () -> Unit
 ) {
     var showAddDialog by remember { mutableStateOf(false) }
-    
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(16.dp)
-    ) {
-        // Header
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Memories") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { showAddDialog = true }) {
+                        Icon(Icons.Default.Add, contentDescription = "Add Memory")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp)
         ) {
             Text(
-                text = "Personal Memory",
-                style = MaterialTheme.typography.headlineMedium,
-                fontWeight = FontWeight.Bold
+                text = "${memories.size} memories stored",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            
-            FloatingActionButton(
-                onClick = { showAddDialog = true },
-                modifier = Modifier.size(56.dp)
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Add,
-                    contentDescription = "Add Memory"
-                )
-            }
-        }
-        
-        Spacer(modifier = Modifier.height(16.dp))
-        
-        // Memory count
-        Text(
-            text = "${memories.size} memories stored",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-        )
-        
-        Spacer(modifier = Modifier.height(16.dp))
-        
-        // Memory list
-        if (memories.isEmpty()) {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            if (memories.isEmpty()) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
                 ) {
-                    Icon(
-                        imageVector = Icons.Default.Star,
-                        contentDescription = null,
-                        modifier = Modifier.size(64.dp),
-                        tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
-                    )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text(
-                        text = "No memories yet",
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-                    )
-                    Text(
-                        text = "Long-press messages in chat to save them as memories",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
-                    )
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Icon(
+                            imageVector = Icons.Default.Star,
+                            contentDescription = null,
+                            modifier = Modifier.size(64.dp),
+                            tint = MaterialTheme.colorScheme.outline
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = "No memories yet",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.outline
+                        )
+                        Text(
+                            text = "Long-press messages in chat to save them as memories",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.outline
+                        )
+                    }
                 }
-            }
-        } else {
-            LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                items(memories) { memory ->
-                    MemoryCard(
-                        memory = memory,
-                        onDelete = { onDeleteMemory(memory.id) }
-                    )
+            } else {
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    items(memories) { memory ->
+                        MemoryCard(
+                            memory = memory,
+                            onDelete = { onDeleteMemory(memory.id) }
+                        )
+                    }
                 }
             }
         }
     }
-    
-    // Add memory dialog
+
     if (showAddDialog) {
         AddMemoryDialog(
             onDismiss = { showAddDialog = false },
@@ -127,9 +119,11 @@ fun MemoryCard(
     onDelete: () -> Unit
 ) {
     var showDeleteDialog by remember { mutableStateOf(false) }
-    
+
     Card(
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
         Column(
             modifier = Modifier.padding(16.dp)


### PR DESCRIPTION
## Summary
- Inject `RagChatRepository` in `ChatViewModel` to enable memory operations and expose flows directly
- Simplify `AppNavGraph` memory route and collect memories state cleanly
- Redesign `MemoryScreen` with themed `TopAppBar`, empty state and card styling

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a862fd98f083289d154b34685c761b