### PR TITLE
feat: export metrics csv from settings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/edu/upt/assistant/data/metrics/MetricsLogger.kt
+++ b/app/src/main/java/edu/upt/assistant/data/metrics/MetricsLogger.kt
@@ -42,8 +42,10 @@ object MetricsLogger {
     private const val FILE_NAME = "generation_metrics.csv"
     private const val HEADER = "timestamp,prefill_ms,first_token_ms,decode_speed,battery_delta,temp_start,temp_end,prompt_chars,prompt_tokens,n_threads,n_batch,n_ubatch,model\n"
 
+    fun getFile(context: Context): File = File(context.filesDir, FILE_NAME)
+
     fun log(context: Context, metrics: GenerationMetrics) {
-        val file = File(context.filesDir, FILE_NAME)
+        val file = getFile(context)
         val isNew = !file.exists()
         if (isNew) {
             file.writeText(HEADER)

--- a/app/src/main/java/edu/upt/assistant/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/edu/upt/assistant/ui/screens/SettingsScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import android.content.Intent
+import android.widget.Toast
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
@@ -46,8 +48,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import androidx.core.content.FileProvider
+import edu.upt.assistant.data.metrics.MetricsLogger
 import edu.upt.assistant.domain.DownloadProgress
 import edu.upt.assistant.domain.ModelDownloadManager
 import edu.upt.assistant.domain.ModelInfo
@@ -79,6 +84,7 @@ fun SettingsScreen(
 
   // Collect live download progress
   val downloadProgress by downloadManager.downloadProgress.collectAsState()
+  val context = LocalContext.current
 
   Scaffold(
     topBar = {
@@ -174,6 +180,30 @@ fun SettingsScreen(
               )
             }
             Switch(checked = autoSaveMemories, onCheckedChange = onAutoSaveMemoriesToggle)
+          }
+
+          Button(
+            onClick = {
+              val file = MetricsLogger.getFile(context)
+              if (!file.exists()) {
+                Toast.makeText(context, "No metrics recorded yet", Toast.LENGTH_SHORT).show()
+              } else {
+                val uri = FileProvider.getUriForFile(
+                  context,
+                  "${context.packageName}.fileprovider",
+                  file
+                )
+                val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                  type = "text/csv"
+                  putExtra(Intent.EXTRA_STREAM, uri)
+                  addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                }
+                context.startActivity(Intent.createChooser(shareIntent, "Share metrics CSV"))
+              }
+            },
+            modifier = Modifier.fillMaxWidth()
+          ) {
+            Text("Export metrics CSV")
           }
         }
       }

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <files-path name="metrics" path="."/>
+</paths>


### PR DESCRIPTION
## Summary
- allow retrieving metrics log file via new `getFile` helper
- enable sharing metrics CSV from Settings screen
- configure file provider for exporting metrics

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c83e66f48328bfe084550482fa83