### PR TITLE
Refine benchmark metrics and add Hit@k support

### DIFF
--- a/app/src/main/java/edu/upt/assistant/data/SettingsKeys.kt
+++ b/app/src/main/java/edu/upt/assistant/data/SettingsKeys.kt
@@ -22,6 +22,7 @@ object SettingsKeys {
   val MAX_TOKENS     = intPreferencesKey("max_tokens")         // default 96
   val TEMP           = floatPreferencesKey("temp")             // default 0.7f
   val MEMORY_ENABLED = booleanPreferencesKey("memory_enabled") // default true
+  val BENCH_CATEGORY = stringPreferencesKey("bench_category")
 
   fun nThreadsForModel(url: String) = intPreferencesKey("n_threads_${url.hashCode()}")
 

--- a/app/src/main/java/edu/upt/assistant/domain/rag/RagChatRepository.kt
+++ b/app/src/main/java/edu/upt/assistant/domain/rag/RagChatRepository.kt
@@ -134,6 +134,7 @@ class RagChatRepository @Inject constructor(
             val ragEnabled   = prefs[SettingsKeys.RAG_ENABLED]    ?: true
             val memoryEnabled= prefs[SettingsKeys.MEMORY_ENABLED] ?: true
             val maxTokensCfg = prefs[SettingsKeys.MAX_TOKENS]     ?: guessMaxTokens(text)
+            val benchCategory= prefs[SettingsKeys.BENCH_CATEGORY] ?: ""
             val modelUrlPref = runBlocking { baseRepository.getModelUrl() }
             val nThreadsCfg  = prefs[SettingsKeys.nThreadsForModel(modelUrlPref)]
                 ?: prefs[SettingsKeys.N_THREADS]
@@ -309,7 +310,7 @@ class RagChatRepository @Inject constructor(
                         retrievedCtxTokens= retrievedCtxTokens,
                         outputTokens      = outputTokApprox,
                         promptId          = conversationId,
-                        category          = "",
+                        category          = benchCategory,
                         ragEnabled        = ragEnabled,
                         memoryEnabled     = memoryEnabled,
                         topK              = if (ragEnabled) docTopK else 0,

--- a/app/src/main/res/raw/benchmark_prompts.json
+++ b/app/src/main/res/raw/benchmark_prompts.json
@@ -14,13 +14,13 @@
   {"id":"memory_pet_recall","category":"memory","text":"Answer with only the pet's name you know about me.","expected_regex":"^Luna$","temp":0.1,"max_tokens":8},
 
   {"id":"rag_capital_doc","category":"rag_setup","doc_id":"france_capital","doc_text":"France is a country in Europe. The capital of France is Paris."},
-  {"id":"rag_capital_question","category":"rag","text":"According to the documents, answer with only the capital of France.","expected_regex":"^Paris$","temp":0.1,"max_tokens":8},
+  {"id":"rag_capital_question","category":"rag","text":"According to the documents, answer with only the capital of France.","expected_regex":"^Paris$","temp":0.1,"max_tokens":8,"ref_doc_id":"france_capital"},
 
   {"id":"rag_history_doc","category":"rag_setup","doc_id":"us_first_president","doc_text":"In 1789, George Washington became the first president of the United States."},
-  {"id":"rag_history_question","category":"rag","text":"From the knowledge base, who was the first president of the United States? Answer with only the name.","expected_regex":"^George\\s+Washington$","temp":0.1,"max_tokens":8},
+  {"id":"rag_history_question","category":"rag","text":"From the knowledge base, who was the first president of the United States? Answer with only the name.","expected_regex":"^George\\s+Washington$","temp":0.1,"max_tokens":8,"ref_doc_id":"us_first_president"},
 
   {"id":"rag_quote_doc","category":"rag_setup","doc_id":"science_quote","doc_text":"Albert Einstein once said, \"Science is a wonderful thing if one does not have to earn one's living at it.\""},
-  {"id":"rag_quote_question","category":"rag","text":"Find a quote about science from the documents. Return the quote text only.","expected_regex":"Science is a wonderful thing","temp":0.3,"max_tokens":48},
+  {"id":"rag_quote_question","category":"rag","text":"Find a quote about science from the documents. Return the quote text only.","expected_regex":"Science is a wonderful thing","temp":0.3,"max_tokens":48,"ref_doc_id":"science_quote"},
 
   {"id":"memory_city_store","category":"memory_setup","insert_memory":"I live in Tirana."},
   {"id":"memory_city_recall","category":"memory","text":"Answer with only the city I live in.","expected_regex":"^Tirana$","temp":0.1,"max_tokens":8},
@@ -32,13 +32,13 @@
   {"id":"memory_club_recall","category":"memory","text":"Answer with only my favorite football club.","expected_regex":"^Real\\s+Madrid$","temp":0.1,"max_tokens":8},
 
   {"id":"rag_water_bp_doc","category":"rag_setup","doc_id":"water_boiling_point","doc_text":"At sea level, the boiling point of water is 100 degrees Celsius."},
-  {"id":"rag_water_bp_question","category":"rag","text":"According to the documents, what is the boiling point of water at sea level? Answer only with the number.","expected_regex":"^100$","temp":0.1,"max_tokens":8},
+  {"id":"rag_water_bp_question","category":"rag","text":"According to the documents, what is the boiling point of water at sea level? Answer only with the number.","expected_regex":"^100$","temp":0.1,"max_tokens":8,"ref_doc_id":"water_boiling_point"},
 
   {"id":"rag_kotlin_doc","category":"rag_setup","doc_id":"kotlin_facts","doc_text":"Kotlin is a statically typed programming language created by JetBrains. It runs on the JVM and was first released in 2011."},
-  {"id":"rag_kotlin_question","category":"rag","text":"From the knowledge base, answer only with the company that created Kotlin.","expected_regex":"^JetBrains$","temp":0.1,"max_tokens":8},
+  {"id":"rag_kotlin_question","category":"rag","text":"From the knowledge base, answer only with the company that created Kotlin.","expected_regex":"^JetBrains$","temp":0.1,"max_tokens":8,"ref_doc_id":"kotlin_facts"},
 
   {"id":"rag_bones_doc","category":"rag_setup","doc_id":"human_bones","doc_text":"An adult human typically has 206 bones in the body."},
-  {"id":"rag_bones_question","category":"rag","text":"According to the documents, how many bones does an adult human have? Answer only with the number.","expected_regex":"^206$","temp":0.1,"max_tokens":8},
+  {"id":"rag_bones_question","category":"rag","text":"According to the documents, how many bones does an adult human have? Answer only with the number.","expected_regex":"^206$","temp":0.1,"max_tokens":8,"ref_doc_id":"human_bones"},
 
   {"id":"general_sort_list","category":"general","text":"Sort ascending and answer only with comma-separated values: 9, 1, 5, 3","expected_regex":"^1,\\s*3,\\s*5,\\s*9$","temp":0.0,"max_tokens":16},
   {"id":"general_unit_convert","category":"general","text":"Answer only with the number: Convert 5 kilometers to meters.","expected_regex":"^5000$","temp":0.0,"max_tokens":16},


### PR DESCRIPTION
## Summary
- Avoid duplicate metrics logging by removing MetricsLogger from BenchmarkRunner and tagging metrics with prompt category
- Compute Hit@k using DocumentRepository and pass reference doc IDs in benchmark prompts
- Add BENCH_CATEGORY DataStore key and propagate to RagChatRepository metrics

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b33dc803b48328b8c82c8178a161cd