### PR TITLE
Guard llama native calls with mutex for safety

### DIFF
--- a/app/src/main/java/edu/upt/assistant/domain/ChatViewModel.kt
+++ b/app/src/main/java/edu/upt/assistant/domain/ChatViewModel.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import edu.upt.assistant.LlamaNative
 import edu.upt.assistant.ui.screens.Conversation
 import edu.upt.assistant.ui.screens.Message
 import edu.upt.assistant.domain.rag.RagChatRepository
@@ -183,8 +182,7 @@ class ChatViewModel @Inject constructor(
             try {
                 val repoImpl = repo as? ChatRepositoryImpl
                 if (repoImpl != null) {
-                    val ctx = repoImpl.getLlamaContextPublic()
-                    LlamaNative.llamaKvCacheClear(ctx)
+                    repoImpl.clearKvCache()
                     Log.d("ChatViewModel", "KV cache cleared successfully")
                 }
             } catch (e: Exception) {


### PR DESCRIPTION
## Summary
- serialize llama.cpp JNI calls with a `Mutex`
- clear KV cache and free context within synchronized blocks
- expose `clearKvCache` method to safely reset cache

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b34099bc208328b4a16f100e5dfde3