### PR TITLE
Log benchmark pass and hit@k metrics

### DIFF
--- a/app/src/main/java/edu/upt/assistant/data/SettingsKeys.kt
+++ b/app/src/main/java/edu/upt/assistant/data/SettingsKeys.kt
@@ -23,6 +23,8 @@ object SettingsKeys {
   val TEMP           = floatPreferencesKey("temp")             // default 0.7f
   val MEMORY_ENABLED = booleanPreferencesKey("memory_enabled") // default true
   val BENCH_CATEGORY = stringPreferencesKey("bench_category")
+  val BENCH_EXPECTED_REGEX = stringPreferencesKey("bench_expected_regex")
+  val BENCH_REF_DOC_ID = stringPreferencesKey("bench_ref_doc_id")
 
   fun nThreadsForModel(url: String) = intPreferencesKey("n_threads_${url.hashCode()}")
 

--- a/app/src/main/java/edu/upt/assistant/data/metrics/MetricsLogger.kt
+++ b/app/src/main/java/edu/upt/assistant/data/metrics/MetricsLogger.kt
@@ -33,6 +33,8 @@ data class GenerationMetrics(
     val model: String,
     val passed: Boolean? = null,
     val output: String? = null,
+    val hitAtK: Boolean? = null,
+    val hitRank: Int? = null,
 ) {
     fun toCsvRow(): String {
         val sanitizedOutput = output?.replace("\"", "\"\"")?.replace("\n", " ") ?: ""
@@ -64,6 +66,8 @@ data class GenerationMetrics(
             model,
             passed?.toString() ?: "",
             outputField,
+            hitAtK?.toString() ?: "",
+            hitRank?.toString() ?: "",
         ).joinToString(",", postfix = "\n")
     }
 }
@@ -71,7 +75,7 @@ data class GenerationMetrics(
 object MetricsLogger {
     private const val FILE_NAME = "generation_metrics.csv"
     private const val HEADER =
-        "timestamp,prefill_ms,first_sample_ms,first_token_ms,decode_ms,decode_speed,battery_delta,temp_start,temp_end,prompt_chars,prompt_tokens,history_tokens,retrieved_ctx_tokens,output_tokens,prompt_id,category,rag_enabled,memory_enabled,top_k,max_tokens,n_threads,n_batch,n_ubatch,model,passed,output\n"
+        "timestamp,prefill_ms,first_sample_ms,first_token_ms,decode_ms,decode_speed,battery_delta,temp_start,temp_end,prompt_chars,prompt_tokens,history_tokens,retrieved_ctx_tokens,output_tokens,prompt_id,category,rag_enabled,memory_enabled,top_k,max_tokens,n_threads,n_batch,n_ubatch,model,passed,output,hit_at_k,hit_rank\n"
     private const val HEADER_LENGTH = HEADER.length
 
     fun getFile(context: Context): File = File(context.applicationContext.filesDir, FILE_NAME)

--- a/app/src/main/java/edu/upt/assistant/domain/BenchmarkRunner.kt
+++ b/app/src/main/java/edu/upt/assistant/domain/BenchmarkRunner.kt
@@ -116,6 +116,8 @@ class BenchmarkRunner @Inject constructor(
 
                     // Tag metrics with benchmark category for RagChatRepository
                     ensureBenchCategory(prompt.category)
+                    ensureExpectedRegex(prompt.expected_regex)
+                    ensureRefDocId(prompt.ref_doc_id)
 
                     val ragOn = lastRag == true
                     val memOn = lastMem == true
@@ -162,6 +164,8 @@ class BenchmarkRunner @Inject constructor(
                     prompt.temp?.let { ensureTemp(null) } // remove override → repo default
                     prompt.max_tokens?.let { ensureMaxTokens(defaultMaxTokens) }
                     ensureBenchCategory(null)
+                    ensureExpectedRegex(null)
+                    ensureRefDocId(null)
                 }
             }
         }
@@ -187,6 +191,20 @@ class BenchmarkRunner @Inject constructor(
         dataStore.edit { prefs ->
             if (cat == null) prefs.remove(SettingsKeys.BENCH_CATEGORY)
             else prefs[SettingsKeys.BENCH_CATEGORY] = cat
+        }
+    }
+
+    private suspend fun ensureExpectedRegex(rx: String?) {
+        dataStore.edit { prefs ->
+            if (rx == null) prefs.remove(SettingsKeys.BENCH_EXPECTED_REGEX)
+            else prefs[SettingsKeys.BENCH_EXPECTED_REGEX] = rx
+        }
+    }
+
+    private suspend fun ensureRefDocId(id: String?) {
+        dataStore.edit { prefs ->
+            if (id == null) prefs.remove(SettingsKeys.BENCH_REF_DOC_ID)
+            else prefs[SettingsKeys.BENCH_REF_DOC_ID] = id
         }
     }
 


### PR DESCRIPTION
## Summary
- add data store keys and logging fields for benchmark regex and reference docs
- capture pass/fail and Hit@k results in repositories and metrics logger
- propagate prompt checks through BenchmarkRunner

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b34840015083288086828e28d2b8e1